### PR TITLE
Improvements to macro logging

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -776,11 +776,12 @@ class settimer(Macro):
         except Exception, e:
             self.output(str(e))
             self.output("%s is not a valid channel"
-                         " in the active measurement group" % timer)
+                        " in the active measurement group" % timer)
 
 
 @macro([['message',
-         ParamRepeat(['message_item', Type.String, None, 'message item to be reported']),
+         ParamRepeat(['message_item', Type.String, None,
+                      'message item to be reported']),
          None, 'message to be reported']])
 def report(self, message):
     """Logs a new record into the message report system (if active)"""
@@ -808,7 +809,6 @@ class logmacro(Macro):
                 self.setEnv('LogMacroMode', True)
             elif mode == 0:
                 self.setEnv('LogMacroMode', False)
-                
             self.setEnv('LogMacro', True)
         else:
             self.setEnv('LogMacro', False)

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -788,7 +788,14 @@ def report(self, message):
 
 
 class logmacro(Macro):
-    """ Turn on/off logging of the spock output """
+    """ Turn on/off logging of the spock output.
+
+    .. note::
+        The logmacro class has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers
+    """
 
     param_def = [
         ['offon', Type.Boolean, None, 'Unset/Set logging'],

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -75,34 +75,9 @@ from sardana.macroserver.msexception import UnknownMacroLibrary, \
 # common location
 from sardana.taurus.core.tango.sardana.macro import createMacroNode
 
+
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-class LogFilter(logging.Filter):
-    # Possible fields: created, name, process, levelname, levelno, funcName, module, message = msg
-    # Ex.:
-    # created   -> 1515147905.34
-    # name      -> Door/issue102/1.Macro[ascan]
-    # process   -> 15638
-    # levelname -> OUTPUT
-    # levelno   -> 15
-    # funcName  -> output
-    # module    -> __init__
-    # message   -> 2         10        0         0         0         0      2.11293 
-
-    def __init__(self, param=None, field=None):
-        self.param = param
-        self.field = field
-
-    def filter(self, record):
-        allow = True
-        if self.param != "MacroExecutor" and "MacroExecutor" in record.name:
-            allow = True
-        elif self.field == "message":
-            allow = self.param not in record.msg
-        elif self.field == "name":
-            allow = self.param not in record.name
-        return allow
-        
 def islambda(f):
     """inspect doesn't come with islambda so I create one :-P"""
     return inspect.isfunction(f) and \
@@ -1361,8 +1336,6 @@ class MacroExecutor(Logger):
                     log_format = logging.Formatter(
                         "%(levelname)-8s %(asctime)s %(name)s: %(message)s")
                 fileHandler.setFormatter(log_format)
-                fileHandler.addFilter(LogFilter("[START]", "message"))
-                fileHandler.addFilter(LogFilter("[ END ]", "message"))
                 logger = macro_obj.getLogger()
                 logger.addHandler(fileHandler)
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -40,8 +40,6 @@ import functools
 import traceback
 import threading
 
-import socket
-
 from lxml import etree
 
 from PyTango import DevFailed
@@ -77,6 +75,7 @@ from sardana.taurus.core.tango.sardana.macro import createMacroNode
 
 
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 def islambda(f):
     """inspect doesn't come with islambda so I create one :-P"""
@@ -904,8 +903,8 @@ class LogMacroManager(object):
 
         door_name = door.name
         # Cleaning name in case alias does not exist
-        door_name = door_name.replace(":","_").replace("/","_")
-        file_name = "session_" + door_name +".log"
+        door_name = door_name.replace(":", "_").replace("/", "_")
+        file_name = "session_" + door_name + ".log"
         log_file = os.path.join(logging_path, file_name)
 
         if logging_mode:
@@ -920,9 +919,9 @@ class LogMacroManager(object):
 
         try:
             format_to_set = macro_obj.getEnv("LogMacroFormat")
-            log_format = logging.Formatter(format_to_set)
-        except:
-            log_format = logging.Formatter(self.DEFAULT_FMT)
+        except UnknownEnv:
+            format_to_set = self.DEFAULT_FMT
+        log_format = logging.Formatter(format_to_set)
         file_handler.setFormatter(log_format)
         macro_obj.addLogHandler(file_handler)
         executor.addLogHandler(file_handler)

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -923,6 +923,8 @@ class LogMacroManager(object):
             format_to_set = self.DEFAULT_FMT
         log_format = logging.Formatter(format_to_set)
         file_handler.setFormatter(log_format)
+        # attach the same handler to two different loggers due to
+        # lack of hierarchy between them (see: sardana-org/sardana#703)
         macro_obj.addLogHandler(file_handler)
         executor.addLogHandler(file_handler)
         return True

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1336,8 +1336,8 @@ class MacroExecutor(Logger):
                     log_format = logging.Formatter(
                         "%(levelname)-8s %(asctime)s %(name)s: %(message)s")
                 fileHandler.setFormatter(log_format)
-                logger = macro_obj.getLogger()
-                logger.addHandler(fileHandler)
+                macro_obj.addLogHandler(fileHandler)
+                self.addLogHandler(fileHandler)
 
         if self._aborted:
             self.sendMacroStatusAbort()
@@ -1424,9 +1424,10 @@ class MacroExecutor(Logger):
                        'Set "%s" environment variable ' % env_var_name +
                        'to True in order to change it.')
             self._macro_pointer = None
-        
-        if logging_onoff:    
-            logger.removeHandler(fileHandler)
+
+        if logging_onoff:
+            macro_obj.removeLogHandler(fileHandler)
+            self.removeLogHandler(fileHandler)
 
         return result
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -849,6 +849,16 @@ class MacroManager(MacroServerManager):
 
 
 class LogMacroManager(object):
+    """Manage user-oriented macro logging to a file. It is configurable with
+    LogMacro, LogMacroMode, LogMacroFormat and LogMacroDir environment
+    variables.
+
+    .. note::
+        The LogMacroManager class has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
+    """
 
     DEFAULT_DIR = os.path.join(os.sep, "tmp")
     DEFAULT_FMT = "%(levelname)-8s %(asctime)s %(name)s: %(message)s"

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -877,7 +877,6 @@ class LogMacroManager(object):
         :return: True or False, depending if logging was enabled or not
         :rtype: boolean
         """
-
         macro_obj = self._macro_obj
         executor = macro_obj.executor
         door = macro_obj.door
@@ -887,8 +886,10 @@ class LogMacroManager(object):
             return False
         # enable logging only if configured by user
         try:
-            self._enabled = macro_obj.getEnv("LogMacro")
+            enabled = macro_obj.getEnv("LogMacro")
         except UnknownEnv:
+            return False
+        if not enabled:
             return False
 
         try:
@@ -927,6 +928,7 @@ class LogMacroManager(object):
         # lack of hierarchy between them (see: sardana-org/sardana#703)
         macro_obj.addLogHandler(file_handler)
         executor.addLogHandler(file_handler)
+        self._enabled = True
         return True
 
     def disable(self):

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1397,7 +1397,7 @@ class MacroExecutor(Logger):
         desc = macro_obj._getDescription()
         door = self.door
 
-        log_macro_manager = MacroExecutor.LogMacroManager(macro_obj)
+        log_macro_manager = LogMacroManager(macro_obj)
         log_macro_manager.enable()
 
         if self._aborted:


### PR DESCRIPTION
I've prepared changes proposed in https://github.com/sardana-org/sardana/pull/480#issuecomment-362250118.

Basically:
* Now we don't add handler to the root logger but to the macro object and macro executor. This way we don't need to filter any logs (at least yet).
* I've encapsulated the log macro logging in a dedicated class.
* Added warning about a provisional API.
