### PR TITLE
Extract getting of filter class to a method and change logic

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -892,7 +892,7 @@ class LogMacroFilter(logging.Filter):
         return allow
 
 
-class LogMacroManager(object):
+class LogMacroManager(Logger):
 
     """Manage user-oriented macro logging to a file. It is configurable with
     LogMacro, LogMacroMode, LogMacroFormat and LogMacroDir environment
@@ -910,6 +910,8 @@ class LogMacroManager(object):
     DEFAULT_MODE = 0
 
     def __init__(self, macro_obj):
+        name = macro_obj.getName() + ".LogMacroManager"
+        Logger.__init__(self, name)
         self._macro_obj = macro_obj
         self._file_handler = None
         self._enabled = False

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -968,10 +968,10 @@ class LogMacroManager(object):
         log_macro_filter = getattr(sardanacustomsettings, "LOG_MACRO_FILTER")
         if isinstance(log_macro_filter, basestring):
             try:
-                moduleName, filterName = log_macro_filter.rsplit('.', 1)
-                __import__(moduleName)
-                module = sys.modules[moduleName]
-                filter_class = getattr(module, filterName)
+                module_name, filter_ame = log_macro_filter.rsplit('.', 1)
+                __import__(module_name)
+                module = sys.modules[module_name]
+                filter_class = getattr(module, filter_name)
                 file_handler.addFilter(filter_class())
             except Exception:
                 file_handler.addFilter(LogMacroFilter())

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -850,7 +850,9 @@ class MacroManager(MacroServerManager):
             self._macro_executors[door] = me = MacroExecutor(door)
         return me
 
+
 class LogMacroFilter(logging.Filter):
+
     def __init__(self, param=None):
         self.param = param
 
@@ -865,31 +867,33 @@ class LogMacroFilter(logging.Filter):
                 start = msg.index("'") + 1
                 end = msg.index("->", start)
                 msg = msg[start:end]
-                msg = msg.replace("("," ").replace(")", "").replace("[", "").replace("]", "")
+                msg = msg.replace("(", " ").replace(")", "").replace(
+                    "[", "").replace("]", "")
                 msg = msg.replace(", ", " ")
                 msg = msg.replace(",", " ")
                 msg = msg.replace(".*", "")
                 while msg.find("  ") != -1:
-                    msg = msg.replace("  "," ")
+                    msg = msg.replace("  ", " ")
                 if msg[0] == "_":
                     allow = False
                 else:
                     msg_split = msg.split(" ")
                     msg = ""
-                    for i in range(0,len(msg_split)):
+                    for i in range(0, len(msg_split)):
                         if msg_split[i].find(" ") == -1:
                             msg_split[i] = msg_split[i].replace("'", " ")
                         msg = msg + " " + str(msg_split[i])
                     while msg.find("  ") != -1:
-                        msg = msg.replace("  "," ")
-                    record.msg = "\n-- " + time.ctime() + "\n" +  msg
+                        msg = msg.replace("  ", " ")
+                    record.msg = "\n-- " + time.ctime() + "\n" + msg
                     allow = True
             else:
                 allow = False
         return allow
 
-    
+
 class LogMacroManager(object):
+
     """Manage user-oriented macro logging to a file. It is configurable with
     LogMacro, LogMacroMode, LogMacroFormat and LogMacroDir environment
     variables.
@@ -961,17 +965,15 @@ class LogMacroManager(object):
         file_handler.doRollover()
 
         from sardana import sardanacustomsettings
-        log_macro_filter = getattr(sardanacustomsettings,"LOG_MACRO_FILTER")
-        print log_macro_filter
+        log_macro_filter = getattr(sardanacustomsettings, "LOG_MACRO_FILTER")
         if isinstance(log_macro_filter, basestring):
-            print "Es basestring"
             try:
                 moduleName, filterName = log_macro_filter.rsplit('.', 1)
                 __import__(moduleName)
                 module = sys.modules[moduleName]
                 filter_class = getattr(module, filterName)
                 file_handler.addFilter(filter_class())
-            except:
+            except Exception:
                 file_handler.addFilter(LogMacroFilter())
 
         try:
@@ -1004,7 +1006,9 @@ class LogMacroManager(object):
 
         return True
 
+
 class MacroExecutor(Logger):
+
     """ """
 
     class RunSubXMLHook:
@@ -1660,7 +1664,7 @@ class MacroExecutor(Logger):
 
     def sendMacroStatus(self, data):
         self._last_macro_status = data
-        #data = self._macro_status_codec.encode(('', data))
+        # data = self._macro_status_codec.encode(('', data))
         return self.door.set_macro_status(data)
 
     def sendRecordData(self, data, codec=None):

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -54,10 +54,10 @@ SPOCK_INPUT_HANDLER = "CLI"
 #: value - recorder name
 SCAN_RECORDER_MAP = None
 
-#: Filter for macro logging: name of the class to be used as filter for the macro logging
+#: Filter for macro logging: name of the class to be used as filter
+#: for the macro logging
 LOG_MACRO_FILTER = "sardana.macroserver.msmacromanager.LogMacroFilter"
 
 # TODO: Temporary solution, available while Taurus3 is being supported.
 # Maximum number of Taurus deprecation warnings allowed to be displayed.
 TAURUS_MAX_DEPRECATION_COUNTS = 0
-


### PR DESCRIPTION
I propose the following logic, I think that this logic gives more flexibility to the users:
- if LOG_MACRO_FILTER is not defined no filter will be used.
- if LOG_MACRO_FILTER is wrongly defined warn user and no filter will be used
- if macro filter can not be initialized warn user and no filter will be used

I also moved the extraction of the filter class to a separate method.
And fixed some tiny flake8 errors.

Hope you like this ideas! I checked it and seems to work well.